### PR TITLE
Update links in getting started and version pages to use routerLink for navigation

### DIFF
--- a/src/app/pages/getting-started/getting-started.page.html
+++ b/src/app/pages/getting-started/getting-started.page.html
@@ -15,7 +15,7 @@
   </div>
   <p>
     You can find the latest release of the DynoC compiler on the
-    <a href="https://github.com/borisonekenobi/DynoC-Docs/releases" target="_blank">GitHub Releases</a> page.
+    <a routerLink="/downloads" routerLinkActive="active">Downloads</a> page.
     Download the version that matches your operating system.
   </p>
 

--- a/src/app/pages/getting-started/getting-started.page.spec.ts
+++ b/src/app/pages/getting-started/getting-started.page.spec.ts
@@ -1,4 +1,5 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {provideRouter} from '@angular/router';
 
 import {GettingStartedPage} from './getting-started.page';
 
@@ -9,6 +10,7 @@ describe('GettingStartedPage', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [GettingStartedPage],
+      providers: [provideRouter([])],
     }).compileComponents();
 
     fixture = TestBed.createComponent(GettingStartedPage);

--- a/src/app/pages/getting-started/getting-started.page.ts
+++ b/src/app/pages/getting-started/getting-started.page.ts
@@ -3,12 +3,15 @@ import {
   PrintLineComponent
 } from '../../components/code/function/print-line/print-line.component';
 import {StringComponent} from '../../components/code/string/string.component';
+import {RouterLink, RouterLinkActive} from '@angular/router';
 
 @Component({
   selector: 'app-getting-started',
   imports: [
     PrintLineComponent,
     StringComponent,
+    RouterLinkActive,
+    RouterLink,
   ],
   templateUrl: './getting-started.page.html',
   styleUrl: './getting-started.page.css',

--- a/src/app/pages/v0.3.0/v0_3_0-page.spec.ts
+++ b/src/app/pages/v0.3.0/v0_3_0-page.spec.ts
@@ -1,7 +1,7 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {provideRouter} from '@angular/router';
 
 import {V0_3_0Page} from './v0_3_0-page';
-import {provideRouter} from '@angular/router';
 
 describe('V030Page', () => {
   let component: V0_3_0Page;
@@ -9,7 +9,8 @@ describe('V030Page', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [V0_3_0Page], providers: [provideRouter([])],
+      imports: [V0_3_0Page],
+      providers: [provideRouter([])],
     }).compileComponents();
 
     fixture = TestBed.createComponent(V0_3_0Page);

--- a/src/app/pages/v0.3.0/v0_3_0-page.ts
+++ b/src/app/pages/v0.3.0/v0_3_0-page.ts
@@ -1,7 +1,7 @@
 import {Component} from '@angular/core';
 import {Version} from '../version';
 import {SidebarComponent} from '../../components/sidebar/sidebar.component';
-import {RouterOutlet} from '@angular/router';
+import {RouterLink, RouterLinkActive, RouterOutlet} from '@angular/router';
 import {
   SidebarElement, SidebarLink, SidebarRedirect,
 } from '../../../sidebar-element';
@@ -22,7 +22,7 @@ import {InputPage} from './stdlib/input/input.page';
 
 @Component({
   selector: 'app-v0.3.0.page',
-  imports: [SidebarComponent, RouterOutlet],
+  imports: [SidebarComponent, RouterOutlet, RouterLink, RouterLinkActive],
   templateUrl: '../version.page.html',
   styleUrl: '../version.page.css',
 })

--- a/src/app/pages/v0.3.16/v0_3_16-page.component.spec.ts
+++ b/src/app/pages/v0.3.16/v0_3_16-page.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {provideRouter} from '@angular/router';
 
 import { V0_3_16Page } from './v0_3_16-page.component';
 
@@ -8,7 +9,8 @@ describe('V031Page', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [V0_3_16Page]
+      imports: [V0_3_16Page],
+      providers: [provideRouter([])],
     })
     .compileComponents();
 

--- a/src/app/pages/v0.3.16/v0_3_16-page.component.ts
+++ b/src/app/pages/v0.3.16/v0_3_16-page.component.ts
@@ -1,13 +1,13 @@
 import {Component} from '@angular/core';
 import {Version} from '../version';
-import {RouterOutlet} from '@angular/router';
+import {RouterLink, RouterLinkActive, RouterOutlet} from '@angular/router';
 import {SidebarComponent} from '../../components/sidebar/sidebar.component';
 import {SidebarElement} from '../../../sidebar-element';
 
 @Component({
   selector: 'app-v0.3.16',
   imports: [
-    RouterOutlet, SidebarComponent],
+    RouterOutlet, SidebarComponent, RouterLink, RouterLinkActive],
   templateUrl: '../version.page.html',
   styleUrl: '../version.page.css',
 })

--- a/src/app/pages/version.page.html
+++ b/src/app/pages/version.page.html
@@ -5,8 +5,10 @@
     @if (this.released) {
       <router-outlet></router-outlet>
     } @else {
-      <p>Still working on it! Check <a href="https://github.com/borisonekenobi/DynoC-Docs/releases" target="_blank">the
-        releases page</a> to see if DynoC v{{ this.version }} has been released yet!</p>
+      <p>
+        Still working on it! Check the <a routerLink="/downloads" routerLinkActive="active">Downloads</a> page to see if
+        DynoC v{{ this.version }} has been released yet!
+      </p>
     }
   </section>
 </div>


### PR DESCRIPTION
This pull request updates references to the DynoC compiler download location throughout the app, replacing direct links to the GitHub Releases page with internal navigation to the new `/downloads` page. It also ensures that Angular's router link directives are imported where needed to support this navigation.

**Download link updates:**

* Updated the download instructions in `getting-started.page.html` to link to the internal `/downloads` page instead of the external GitHub Releases page.
* Updated the version information in `version.page.html` to prompt users to check the `/downloads` page for new releases, replacing the previous link to the GitHub releases page.

**Angular router integration:**

* Added `RouterLink` and `RouterLinkActive` imports to `getting-started.page.ts` and included them in the component's imports to enable internal navigation.
* Added `RouterLink` and `RouterLinkActive` to the imports of the v0.3.16 version component to support router-based navigation in version pages.